### PR TITLE
Feat/front/multiple-fixes-refactors

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,10 +38,10 @@ function App() {
 
   return (
     <Router>
-      <div>
+      <div className='max-w-[400px] m-auto'>
         <Navbar isLoggedIn={isLoggedIn} />
         <main className='
-        relative top-[25vw]
+        relative top-[75px]
         sm:top-60
         '>
           <Routes>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -43,7 +43,6 @@ function App() {
         <main className='
         relative top-[25vw]
         sm:top-60
-        z-0
         '>
           <Routes>
             <Route path="/" element={<Main />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,7 +42,6 @@ function App() {
         <Navbar isLoggedIn={isLoggedIn} />
         <main className='
         relative top-[75px]
-        sm:top-60
         '>
           <Routes>
             <Route path="/" element={<Main />} />

--- a/frontend/src/components/CardDriverTrip.jsx
+++ b/frontend/src/components/CardDriverTrip.jsx
@@ -1,17 +1,18 @@
+import PropTypes from 'prop-types';
 import location from '../assets/location.png';
 import passenger from '../assets/pasajero.png'
 import passengerOne from '../assets/pasajerouno.png';
 import passengerTwo from '../assets/pasajerodos.png';
 import { Link } from 'react-router-dom';
 
-function CardDriverTrip() {
+function CardDriverTrip({date, origin, destination, startTime, endTime}) {
   return (
     <article className="border border-customGreen rounded-md m-4 p-4 shadow-lg">
         <div className='flex absolute right-10 top-58'>
         <img src={passenger} alt="" />
         <p className='text-customGreen font-bold'>x1</p>
       </div>
-      <h2>Jueves 13 de junio 2024</h2>
+      <h2>{date}</h2>
       <section id="locations" className="flex items-center justify-center w-full mt-4">
             <div id="location-bar-icon" className="flex flex-col justify-center items-center gap-1 p-2">
               <img src={location} alt="location" className="w-[24px] h-[27px]" />
@@ -20,12 +21,12 @@ function CardDriverTrip() {
             </div>
             <div id="location-text-container" className="min-h-[120px] flex flex-col justify-between gap-3 p-1 w-full">
               <div>
-                <p className="text-[13px] text-textColor font-semibold">Mar del plata, Buenos Aires</p>
-                <p className="text-gray-700 text-[11px]">10:00hs</p>
+                <p className="text-[13px] text-textColor font-semibold">{origin}</p>
+                <p className="text-gray-700 text-[11px]">{startTime}</p>
               </div>
               <div>
-                <p className="text-[13px] text-textColor font-semibold">Capital Federal, Buenos Aires</p>
-                <p className="text-gray-700 text-[11px]">15:30hs</p>
+                <p className="text-[13px] text-textColor font-semibold">{destination}</p>
+                <p className="text-gray-700 text-[11px]">{endTime}</p>
               </div>
             </div>
           </section>
@@ -45,4 +46,12 @@ function CardDriverTrip() {
   )
 }
 
-export default CardDriverTrip
+CardDriverTrip.propTypes = {
+  date: PropTypes.string.isRequired,
+  origin: PropTypes.string.isRequired,
+  destination: PropTypes.string.isRequired,
+  startTime: PropTypes.string.isRequired,
+  endTime: PropTypes.string.isRequired,
+};
+
+export default CardDriverTrip;

--- a/frontend/src/components/GoHomeBtn.jsx
+++ b/frontend/src/components/GoHomeBtn.jsx
@@ -1,11 +1,17 @@
 import { Link } from "react-router-dom"
+// I need to import porp types below:
+import { PropTypes } from 'prop-types'
 
-const GoHomeBtn = () => {
+const GoHomeBtn = ({to}) => {
   return (
     <button className="w-[103px] h-14 border border-customGreen text-customGreen rounded-full m-6 p-2">
-    <Link to="/trips">ir a inicio</Link>
+    <Link to={to||"/trips"}>ir a inicio</Link>
     </button>
   )
+}
+
+GoHomeBtn.propTypes = {
+  to: PropTypes.string
 }
 
 export default GoHomeBtn

--- a/frontend/src/components/NextBtn.jsx
+++ b/frontend/src/components/NextBtn.jsx
@@ -12,5 +12,6 @@ export const NextBtn = ({ to, onClick }) => {
 }
 
 NextBtn.propTypes = {
-  to: PropTypes.string.isRequired
+  to: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
 }

--- a/frontend/src/components/NextBtn.jsx
+++ b/frontend/src/components/NextBtn.jsx
@@ -1,9 +1,11 @@
 import { PropTypes } from 'prop-types';
 import { Link } from 'react-router-dom';
 
-export const NextBtn = ({ to }) => {
+export const NextBtn = ({ to, onClick }) => {
   return (
-    <button className="w-[165px] h-14 bg-customGreen text-white rounded-full m-6 p-2">
+    <button 
+      onClick={onClick}
+      className="w-[165px] h-14 bg-customGreen text-white rounded-full m-6 p-2">
         <Link to={to} >Continuar</Link>
     </button>
   )

--- a/frontend/src/components/PassengerDriverBtn.jsx
+++ b/frontend/src/components/PassengerDriverBtn.jsx
@@ -1,7 +1,17 @@
 import { useState } from 'react';
 
-const PassengerDriverBtn = () => {
+const PassengerDriverBtn = ({ setDriverIsActive }) => {
   const [active, setActive] = useState('Driver');
+
+  const handlePassengerClick = () => {
+    setActive('Passenger');
+    setDriverIsActive(false);
+  };
+
+  const handleDriverClick = () => {
+    setActive('Driver');
+    setDriverIsActive(true);
+  };
 
   return (
     <div className="flex w-[157px] h-[41px] rounded-full border border-gray-300 bg-gray-100">
@@ -9,7 +19,7 @@ const PassengerDriverBtn = () => {
       className={`flex-1 text-center py-2 cursor-pointer rounded-l-full ${
         active === 'Passenger' ? 'bg-customGreen text-white' : 'text-gray-500'
       }`}
-      onClick={() => setActive('Passenger')}
+      onClick={handlePassengerClick}
     >
       Pasajero
     </div>
@@ -17,12 +27,12 @@ const PassengerDriverBtn = () => {
       className={`flex-1 text-center py-2 px-1 cursor-pointer rounded-r-full ${
         active === 'Driver' ? 'bg-customGreen text-white' : 'text-gray-500'
       }`}
-      onClick={() => setActive('Driver')}
+      onClick={handleDriverClick}
     >
       Conductor
     </div>
   </div>
-  )
+  );
 }
 
-export default PassengerDriverBtn
+export default PassengerDriverBtn;

--- a/frontend/src/components/PassengerDriverBtn.jsx
+++ b/frontend/src/components/PassengerDriverBtn.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { PropTypes } from 'prop-types';
 
 const PassengerDriverBtn = ({ setDriverIsActive }) => {
   const [active, setActive] = useState('Driver');
@@ -33,6 +34,10 @@ const PassengerDriverBtn = ({ setDriverIsActive }) => {
     </div>
   </div>
   );
+}
+
+PassengerDriverBtn.propTypes = {
+  setDriverIsActive: PropTypes.func,
 }
 
 export default PassengerDriverBtn;

--- a/frontend/src/components/navbar/Menu.jsx
+++ b/frontend/src/components/navbar/Menu.jsx
@@ -10,6 +10,7 @@ import chat from '../../assets/navbar/chat.svg';
 
 const Menu = ({ isActive, setIsActive }) => {
   const user = useSelector((state) => state.user.data);
+  const isDriver = user && user.rol && user.rol.length > 1||false;
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   useEffect(() => {
     setIsLoggedIn(user?true:false);
@@ -36,7 +37,7 @@ const Menu = ({ isActive, setIsActive }) => {
           <Item text="Perfil" onClick={handleOnClick} icon={userIcon} to="#"/>
           <Item text="Chat" onClick={handleOnClick} icon={chat} to="#"/>
           <Item text="Mis viajes" onClick={handleOnClick} icon={car} to="#"/>
-          <Item text="Quiero ser conductor" onClick={handleOnClick} icon={driving} to="/register/driver"/>
+          { isDriver ? null : <Item text="Quiero ser conductor" onClick={handleOnClick} icon={driving} to="/register/driver"/> }
           <Item text="Ayuda" onClick={handleOnClick} icon={help} to="#" />
         </>
       ) : (

--- a/frontend/src/components/navbar/Menu.jsx
+++ b/frontend/src/components/navbar/Menu.jsx
@@ -24,7 +24,7 @@ const Menu = ({ isActive, setIsActive }) => {
          z-10 fixed  
          border-2 rounded-3xl
          pt-[17vw] sm:pt-[25vw]
-         w-full h-screen
+         w-full max-w-[400px] h-screen
          transition-all duration-500 ease-in-out ${
            isActive ? 'top-0' : 'top-[-100%]'
          } 

--- a/frontend/src/components/navbar/Menu.jsx
+++ b/frontend/src/components/navbar/Menu.jsx
@@ -1,6 +1,6 @@
 import { PropTypes } from 'prop-types';
 import { useSelector } from 'react-redux';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import Item from './Item';
 import help from '../../assets/navbar/help.svg';
 import userIcon from '../../assets/navbar/user.svg';
@@ -11,10 +11,10 @@ import chat from '../../assets/navbar/chat.svg';
 const Menu = ({ isActive, setIsActive }) => {
   const user = useSelector((state) => state.user.data);
   const isDriver = user && user.rol && user.rol.length > 1||false;
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  
   useEffect(() => {
-    setIsLoggedIn(user?true:false);
   }, [user]);
+
   const handleOnClick = () => {
     setIsActive(false);
   };
@@ -32,9 +32,9 @@ const Menu = ({ isActive, setIsActive }) => {
          bg-white px-2 py-8
          `}
     >
-      {isLoggedIn ? (
+      {user._id ? (
         <>
-          <Item text="Perfil" onClick={handleOnClick} icon={userIcon} to="#"/>
+          <Item text="Perfil" onClick={handleOnClick} icon={userIcon} to={user}/>
           <Item text="Chat" onClick={handleOnClick} icon={chat} to="#"/>
           <Item text="Mis viajes" onClick={handleOnClick} icon={car} to="#"/>
           { isDriver ? null : <Item text="Quiero ser conductor" onClick={handleOnClick} icon={driving} to="/register/driver"/> }
@@ -55,7 +55,6 @@ const Menu = ({ isActive, setIsActive }) => {
 Menu.propTypes = {
   isActive: PropTypes.bool.isRequired,
   setIsActive: PropTypes.func.isRequired,
-  isLoggedIn: PropTypes.bool.isRequired,
 };
 
 export default Menu;

--- a/frontend/src/components/navbar/Menu.jsx
+++ b/frontend/src/components/navbar/Menu.jsx
@@ -43,6 +43,7 @@ const Menu = ({ isActive, setIsActive }) => {
       ) : (
         <>
           <Item text="Crear cuenta" onClick={handleOnClick} icon={userIcon} to="/register/step-1" />
+          <Item text="Ingresar" onClick={handleOnClick} icon={userIcon} to="/login" />
           <Item text="Nosotros" onClick={handleOnClick} icon={car} to="/"/>
           <Item text="Quiero ser conductor" onClick={handleOnClick} icon={driving} to="/register/step-1"/>
           <Item text="Ayuda" onClick={handleOnClick} icon={help} to="#"/>

--- a/frontend/src/components/navbar/Navbar.jsx
+++ b/frontend/src/components/navbar/Navbar.jsx
@@ -9,13 +9,13 @@ import menuIcon from '../../assets/menu-icon-hamb.svg';
 const Navbar = ({isLoggedIn}) => {
   const [isActive, setIsActive] = useState(false);
   return (
-    <nav className="fixed z-30 w-full top-0">
+    <nav className="fixed z-30 w-full max-w-[400px] top-0">
       <img
         src={bgNavCurve}
         alt="background"
         className="z-20 
         fixed 
-        w-full top-0"
+        w-full max-w-[400px] top-0"
       />
       <div className="flex items-center justify-center z-30 relative top-0 pt-2 w-full">
         <Link to="/trips" className="flex items-center border-white w-3/4 justify-center">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,17 +1,27 @@
-import { useSelector } from "react-redux";
-import formatDate from "../store/utils/formatDate";
-import sortTripsByDate from "../store/utils/sortTripsByDate";
-import CardTrip from "../components/CardTrip"
-import DriverButton from "../components/DriverButton";
-import mainProfilePicture from '../assets/main-profilepic.png'
-import auto from '../assets/auto.png'
-import DateDisplay from "../components/DateDisplay";
+import { useSelector } from 'react-redux';
+import formatDate from '../store/utils/formatDate';
+import sortTripsByDate from '../store/utils/sortTripsByDate';
+import CardTrip from '../components/CardTrip';
+import DriverButton from '../components/DriverButton';
+import mainProfilePicture from '../assets/main-profilepic.png';
+import auto from '../assets/auto.png';
+import DateDisplay from '../components/DateDisplay';
+import PassengerDriverBtn from '../components/PassengerDriverBtn';
+import ProfileDriver from './profile-driver/ProfileDriver';
+import { useState } from 'react';
 
 const Home = () => {
+  const { fullName, rol } = useSelector((state) => state.user.data || {});
+  const isDriver = rol && rol.length > 1 ? true : false;
+  const [driverIsActive, setDriverIsActive] = useState(false);
+  console.log('si driver active?', driverIsActive);
   const trips = useSelector((state) => state.trips.list);
   const tripsByDate = sortTripsByDate(trips);
-  const sortedDates = Object.keys(tripsByDate).sort((a, b) => new Date(a) - new Date(b));
-  const {fullName, rol} = useSelector((state) => state.user.data || {});
+  const sortedDates = Object.keys(tripsByDate).sort(
+    (a, b) => new Date(a) - new Date(b)
+  );
+  
+
   return (
     <main className="mt-10">
       <section className="flex flex-row items-center justify-center">
@@ -20,11 +30,15 @@ const Home = () => {
           <h1 className="text-center text-2xl font-extrabold text-mainTitle text-textColor mb-2">
             {`¡Hola, ${fullName || 'invitado'}!`}
           </h1>
-          {rol&&rol[1] === "driver" ? null : <DriverButton />}
+          {rol && rol[1] === 'driver' ? null : <DriverButton />}
+          { isDriver && <PassengerDriverBtn setDriverIsActive={setDriverIsActive} />}
         </div>
       </section>
-
+      {driverIsActive && <ProfileDriver />}
+      {!driverIsActive && <>
       <div className="flex flex-row items-center justify-center">
+        
+
         <h1 className="text-customGreen font-extrabold text-mainTitle text-xl m-2">
           Viajes disponibles
         </h1>
@@ -51,8 +65,10 @@ const Home = () => {
           </section>
         ))}
       </section>
+      </>
+      }
     </main>
   );
-}
+};
 
-export default Home
+export default Home;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -20,7 +20,7 @@ const Home = () => {
           <h1 className="text-center text-2xl font-extrabold text-mainTitle text-textColor mb-2">
             {`¡Hola, ${fullName || 'invitado'}!`}
           </h1>
-          {rol === "driver" ? null : <DriverButton />}
+          {rol&&rol[1] === "driver" ? null : <DriverButton />}
         </div>
       </section>
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -29,7 +29,7 @@ const Login = ({setIsLoggedIn}) => {
     navigate('/register/step-1');
   };
   return (
-    <section className="flex flex-col w-screen h-screen m-0 items-center gap-4 pl-[48px] pr-[40px] pt-[20vw]">
+    <section className="flex flex-col w-full h-full m-0 items-center gap-4 pl-[48px] pr-[40px] pt-[20vw]">
       <h1 className="my-2 text-[22px] font-medium">Iniciar sesión</h1>
       <form className="flex flex-col w-full items-center justify-around">
         <Input 

--- a/frontend/src/pages/profile-driver/DriverDetailTrip.jsx
+++ b/frontend/src/pages/profile-driver/DriverDetailTrip.jsx
@@ -32,8 +32,8 @@ const DriverDetailTrip = () => {
   }
 
   return (
-    <main>
-      <div className="absolute top-0">
+    <main className='absolute top-[-75px] sm:top-[-250px] z-40 bg-white'>
+      <div className="relative top-0 max-w-[400px]">
         <NavDetailsTrip name="Marcos" />
       <section className="mt-[10vw] sm:pt-[10vw] sm:mt-[20vw] px-4 flex flex-col gap-8 items-center">
         <h1 className="text-[#696969]">Detalle del Viaje</h1>

--- a/frontend/src/pages/profile-driver/NavDetailsTrip.jsx
+++ b/frontend/src/pages/profile-driver/NavDetailsTrip.jsx
@@ -5,7 +5,7 @@ import driverProfile from '../../assets/main-profilepic.png'
 
 const NavDetailsTrip = ({ name }) => {
   return (
-    <section className="w-screen relative text-white">
+    <section className="w-full relative text-white">
       <img src={curve} alt="curve" className="w-full z-10 absolute"/>
       <div className="relative z-20 flex pt-4">
         <div className="flex items-start">

--- a/frontend/src/pages/profile-driver/ProfileDriver.jsx
+++ b/frontend/src/pages/profile-driver/ProfileDriver.jsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react'
-import driverProfile from '../../assets/main-profilepic.png'
 import CardDriverTrip from '../../components/CardDriverTrip'
 import DriverDocuments from '../../components/DriverDocuments'
 import LastTripCard from '../../components/LastTripCard'
-import PassengerDriverBtn from '../../components/PassengerDriverBtn'
 import { Link, useLocation } from 'react-router-dom'
 
 const ProfileDriver = () => {
@@ -17,14 +15,7 @@ const ProfileDriver = () => {
   }, [location]);
 
   return (
-    <main className='mt-10 flex flex-col'>
-      <section className="flex flex-row items-center justify-center">
-          <img src={driverProfile} alt=""/>
-          <div className="m-4">
-            <h1 className="text-center text-2xl font-extrabold text-mainTitle text-textColor mb-2">Marcos</h1>
-            <PassengerDriverBtn />
-          </div>
-        </section>
+    <div className='flex flex-col '>
         <div className="flex flex-row items-center justify-center mt-4">
           <h1 className="text-customGreen font-extrabold text-mainTitle text-xl m-2">Viajes disponibles</h1>
         </div>
@@ -48,7 +39,7 @@ const ProfileDriver = () => {
           <h2 className='font-semibold text-[18px] ml-4'>Último viaje realizado</h2>
           <LastTripCard />
         </section>
-    </main>
+        </div>
   )
 }
 

--- a/frontend/src/pages/profile-driver/ProfileDriver.jsx
+++ b/frontend/src/pages/profile-driver/ProfileDriver.jsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux'
 const ProfileDriver = () => {
   const myDriverID = useSelector((state)=>state.user.data._id)
   const trips = useSelector((state)=>state.trips.list)
-  const myTrips = trips.filter((trip) => trip.driver._id === myDriverID) || [];
+  const myTrips = trips.filter((trip) => trip.driver && trip.driver._id === myDriverID) || [];
 
   return (
     <div className="flex flex-col ">

--- a/frontend/src/pages/profile-driver/ProfileDriver.jsx
+++ b/frontend/src/pages/profile-driver/ProfileDriver.jsx
@@ -5,31 +5,23 @@ import LastTripCard from '../../components/LastTripCard'
 import { Link, useLocation } from 'react-router-dom'
 
 const ProfileDriver = () => {
-  const [isTripDeleted, setIstripDeleted] = useState(false);
-  const location = useLocation();
-
-  useEffect(() => {
-    if(location.state && location.state.tripDeleted) {
-    setIstripDeleted(true);
-    }
-  }, [location]);
-
+  const [isNoTrips, setIsNoTrips] = useState(true);
+  
   return (
     <div className='flex flex-col '>
         <div className="flex flex-row items-center justify-center mt-4">
           <h1 className="text-customGreen font-extrabold text-mainTitle text-xl m-2">Viajes disponibles</h1>
         </div>
         <section>
-          { isTripDeleted ? (
+          { isNoTrips && (
               <div className='flex items-center justify-between'>
                 <h2 className='font-semibold text-[18px] ml-4'>Comenza a ahorrar</h2>
                 <button className="w-[100px] h-[45px] bg-customGreen text-white rounded-full m-6 p-2">
                   <Link to="/trips/new/step-1">Crear viaje</Link>
                 </button>
               </div>
-            ) : (
-              <CardDriverTrip />
           )}
+        <CardDriverTrip /> 
         </section>
         <section>
           <h2 className='font-semibold text-[18px] ml-4'>Mis documentos</h2>

--- a/frontend/src/pages/profile-driver/ProfileDriver.jsx
+++ b/frontend/src/pages/profile-driver/ProfileDriver.jsx
@@ -3,36 +3,54 @@ import CardDriverTrip from '../../components/CardDriverTrip'
 import DriverDocuments from '../../components/DriverDocuments'
 import LastTripCard from '../../components/LastTripCard'
 import { Link, useLocation } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 const ProfileDriver = () => {
-  const [isNoTrips, setIsNoTrips] = useState(true);
-  
+  const myDriverID = useSelector((state)=>state.user.data._id)
+  const trips = useSelector((state)=>state.trips.list)
+  const myTrips = trips.filter((trip) => trip.driver._id === myDriverID);
+
   return (
-    <div className='flex flex-col '>
-        <div className="flex flex-row items-center justify-center mt-4">
-          <h1 className="text-customGreen font-extrabold text-mainTitle text-xl m-2">Viajes disponibles</h1>
-        </div>
-        <section>
-          { isNoTrips && (
-              <div className='flex items-center justify-between'>
-                <h2 className='font-semibold text-[18px] ml-4'>Comenza a ahorrar</h2>
-                <button className="w-[100px] h-[45px] bg-customGreen text-white rounded-full m-6 p-2">
-                  <Link to="/trips/new/step-1">Crear viaje</Link>
-                </button>
-              </div>
-          )}
-        <CardDriverTrip /> 
-        </section>
-        <section>
-          <h2 className='font-semibold text-[18px] ml-4'>Mis documentos</h2>
-          <DriverDocuments />
-        </section>
-        <section>
-          <h2 className='font-semibold text-[18px] ml-4'>Último viaje realizado</h2>
-          <LastTripCard />
-        </section>
-        </div>
-  )
+    <div className="flex flex-col ">
+      <div className="flex flex-row items-center justify-center mt-4">
+        <h1 className="text-customGreen font-extrabold text-mainTitle text-xl m-2">
+          Viajes disponibles
+        </h1>
+      </div>
+      <section>
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold text-[18px] ml-4">
+              Comenza a ahorrar
+            </h2>
+            <button className="w-[100px] h-[45px] bg-customGreen text-white rounded-full m-6 p-2">
+              <Link to="/trips/new/step-1">Crear viaje</Link>
+            </button>
+          </div>
+        {myTrips.map((trip) => (
+          <CardDriverTrip 
+          key={trip._id}
+          date={trip.origin.date}
+          origin={trip.origin.address + ", " + trip.origin.city}
+          destination={trip.destination.address + ", " + trip.destination.city}
+          startTime={trip.origin.time}
+          endTime={trip.destination.time}
+          />
+        ))}
+
+        
+      </section>
+      <section>
+        <h2 className="font-semibold text-[18px] ml-4">Mis documentos</h2>
+        <DriverDocuments />
+      </section>
+      <section>
+        <h2 className="font-semibold text-[18px] ml-4">
+          Último viaje realizado
+        </h2>
+        <LastTripCard />
+      </section>
+    </div>
+  );
 }
 
 export default ProfileDriver

--- a/frontend/src/pages/profile-driver/ProfileDriver.jsx
+++ b/frontend/src/pages/profile-driver/ProfileDriver.jsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react'
 import CardDriverTrip from '../../components/CardDriverTrip'
 import DriverDocuments from '../../components/DriverDocuments'
 import LastTripCard from '../../components/LastTripCard'
-import { Link, useLocation } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 
 const ProfileDriver = () => {

--- a/frontend/src/pages/profile-driver/ProfileDriver.jsx
+++ b/frontend/src/pages/profile-driver/ProfileDriver.jsx
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux'
 const ProfileDriver = () => {
   const myDriverID = useSelector((state)=>state.user.data._id)
   const trips = useSelector((state)=>state.trips.list)
-  const myTrips = trips.filter((trip) => trip.driver._id === myDriverID);
+  const myTrips = trips.filter((trip) => trip.driver._id === myDriverID) || [];
 
   return (
     <div className="flex flex-col ">

--- a/frontend/src/pages/register/driver/CarRegister.jsx
+++ b/frontend/src/pages/register/driver/CarRegister.jsx
@@ -1,8 +1,18 @@
+
+import { useState } from "react"
+import { useDispatch, useSelector } from 'react-redux';
+import registerDriver from '../../../store/requests/registerDriver'
 import Input from "../../../components/Input"
 import imagenAdjuntar from '../../../assets/Imagen-adjuntar.png'
 import { NextBtn } from "../../../components/NextBtn"
 
 const CarRegister = () => {
+  const dispatch = useDispatch();
+  const [makeAndModel, setMakeAndModel] = useState("");
+  const driver = useSelector((state)=> state.user.data._id)
+  const handleSubmit = ()=>{
+    dispatch(registerDriver({driver, makeAndModel}));
+  }
   return (
     <main className="mt-20">
       <h2 className='text-textColor font-extrabold text-mainTitle text-[26px] text-center'>Ultimo paso</h2>
@@ -12,8 +22,11 @@ const CarRegister = () => {
         <form action="">
           <h2 className="font-semibold">Marca y modelo</h2>
           <Input 
-          type="text"
-          placeholder='volkswagen - Golf'
+            type="text"
+            placeholder='volkswagen - Golf'
+            value={makeAndModel}
+            onChange={(e) => setMakeAndModel(e.target.value)}
+            required={true}
           />
         </form>
       </section>
@@ -27,7 +40,8 @@ const CarRegister = () => {
       </section>
       <section className="flex items-center justify-center">
         <NextBtn 
-        to="/register/vehicle-end"
+         onClick={handleSubmit}
+         to="/register/vehicle-end"
         />
       </section>
     </main>

--- a/frontend/src/pages/register/driver/DriverRegister.jsx
+++ b/frontend/src/pages/register/driver/DriverRegister.jsx
@@ -1,7 +1,15 @@
+import { useEffect } from 'react'
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import tarjetadeidentificacion from '../../../assets/tarjeta-de-identificacion.png'
 import RegisterBtn from '../../../components/RegisterBtn'
 
 const DriverRegister = () => {
+  const navigate = useNavigate();
+  const isUser = useSelector((state)=> state.user.data);
+  useEffect(()=>{
+    isUser._id ? null : navigate('/register/step-1');
+  },[navigate,isUser]);
   return (
     <main className='mt-20 flex items-center flex-col'>
       <h2 className='text-textColor font-extrabold text-mainTitle text-[26px]' >¿Queres ser conductor?</h2>

--- a/frontend/src/pages/register/user/CreateAccountEnd.jsx
+++ b/frontend/src/pages/register/user/CreateAccountEnd.jsx
@@ -21,7 +21,7 @@ const CreateAccountEnd = () => {
       </section>
       <section className='m-5 flex justify-center'>
         <button className="w-[103px] h-14 border border-customGreen text-customGreen rounded-full m-6 p-2">
-          <Link to="/trips/new/step-1">Crear viaje</Link>
+          <Link to="/register/driver">Crear viaje</Link>
         </button>
         <button className='w-[103px] h-14 bg-customGreen text-white rounded-full m-6'>
           <Link to="/trips">Ver viajes</Link>

--- a/frontend/src/pages/trips/ReserveTrip.jsx
+++ b/frontend/src/pages/trips/ReserveTrip.jsx
@@ -28,7 +28,7 @@ const ReserveTrip = () => {
   }
 
   return (
-    <div className="absolute top-0">
+    <div className="absolute top-[-25vw] z-40 bg-white">
       <BackNav 
       text="Reservar viaje"
       to={"/trips/:id/details"}

--- a/frontend/src/pages/trips/TripDetails.jsx
+++ b/frontend/src/pages/trips/TripDetails.jsx
@@ -25,7 +25,7 @@ const TripDetails = () => {
   }
 
   return (
-    <div className="absolute top-0">
+    <div className="absolute top-[-25vw] z-40 bg-white">
       <TripDetailsTop 
       name="Elena"
       bio="“Tengo 45 años y viajo todos los dias por mi trabajo a mardel.”"

--- a/frontend/src/pages/trips/TripDetails.jsx
+++ b/frontend/src/pages/trips/TripDetails.jsx
@@ -25,7 +25,7 @@ const TripDetails = () => {
   }
 
   return (
-    <div className="absolute top-[-25vw] z-40 bg-white">
+    <div className="absolute top-[-25vw] sm:top-[-250px] z-40 bg-white">
       <TripDetailsTop 
       name="Elena"
       bio="“Tengo 45 años y viajo todos los dias por mi trabajo a mardel.”"

--- a/frontend/src/pages/trips/TripDetails.jsx
+++ b/frontend/src/pages/trips/TripDetails.jsx
@@ -38,7 +38,7 @@ const TripDetails = () => {
           </Link>
         </button>
       </div>
-      <div className="mt-[10vw] sm:pt-[10vw] sm:mt-[20vw] px-4 flex flex-col gap-8 items-center">
+      <div className="mt-[10vw] sm:mt-[25px] sm:pt-[10vw]  px-4 flex flex-col gap-8 items-center">
         <h1 className="text-[#696969]">Detalle del Viaje</h1>
         <div className="flex text-sm items-center justify-between w-full">
           <DateDisplay date={trip.origin.date} />

--- a/frontend/src/pages/trips/TripDetailsTop.jsx
+++ b/frontend/src/pages/trips/TripDetailsTop.jsx
@@ -6,7 +6,7 @@ const TripDetailsTop = ({ name, bio, driverProfile }) => {
   return (
     <section
       className="
-    w-screen  
+    w-full  
     relative
     text-white"
     >

--- a/frontend/src/store/requests/registerDriver.js
+++ b/frontend/src/store/requests/registerDriver.js
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { VITE_API_URL_BASE as API_URL_BASE} from "../../config";
 
-const registerUser = createAsyncThunk('user/register', async (user,{ rejectWithValue })=>{
+const registerUser = createAsyncThunk('driver/register', async (user,{ rejectWithValue })=>{
     try{
       const response = await fetch(`${API_URL_BASE}/register/driver`, {
         method: 'POST',

--- a/frontend/src/store/requests/registerDriver.js
+++ b/frontend/src/store/requests/registerDriver.js
@@ -3,7 +3,7 @@ import { VITE_API_URL_BASE as API_URL_BASE} from "../../config";
 
 const registerUser = createAsyncThunk('user/register', async (user,{ rejectWithValue })=>{
     try{
-      const response = await fetch(`${API_URL_BASE}/register`, {
+      const response = await fetch(`${API_URL_BASE}/register/driver`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/store/slices/userSlice.js
+++ b/frontend/src/store/slices/userSlice.js
@@ -43,6 +43,9 @@ export const userSlice = createSlice({
       .addCase("user/authenticate/fulfilled", (state, action)=> {
         return { ...state, ...action.payload }
       }) 
+      .addCase("user/register/fulfilled", (state, action) => {
+        return { ...state, ...action.payload}
+      })
   },
 });
 

--- a/frontend/src/store/slices/userSlice.js
+++ b/frontend/src/store/slices/userSlice.js
@@ -46,6 +46,10 @@ export const userSlice = createSlice({
       .addCase("user/register/fulfilled", (state, action) => {
         return { ...state, ...action.payload}
       })
+      .addCase("driver/register/fulfilled", (state, action) => {
+        state.data = { ...state.data, ...action.payload };
+      })
+      
   },
 });
 


### PR DESCRIPTION
# Fixes and Refactors

**Set max with of 400 px since this app is not responsive yet**
- App.jsx
  - Set max with of 400px
  - Fix Wrogn overlapping with the navigation bar
- Navigation bar
  - fix rendering if the user is the driver or not
  - update max with to 400 px
  - Add an option to log in to improve user experience.
- Home
  - get fullName and rol from glogal state
  - Conditionally renders elements in the user is the driver or not
  - Conditionally renders elements if the user is logged or not.
  - Trips are rendered if they exist, separated by date but this feature still needs to be improved
- Login
  - change max from screen to full (to avoid overflow)
- DriverDetailTrip:
  - Adjust top, z-index, and max with of elements to avoid overflow
- CarDriverTrip:
  - Renders data from props and includes props validation
    - date,
    - origin
    - destination
    - startTime
    - EndTiem
- GoHOmeBtn.jsx
  - add prop `to` to pass an optional relative link reference
- NexBtn.jsx
  - accepts an optional onClick function
- PassengerDriverBtn.jsx(the one that is a switch)
  - pass setter `setDriverIsActive` to update state to be able to trigger a conditional rendering
- NavDetailsTrip:
  - Adjust from screen to full to avoid overflow issued
- ProfileDriver
 - Removes initial logic
 - get trips from global storage
 - filter trips created by the user(if they have created some trips)
 - refactor to render filtered trips.
- Car register:
 - gather all data from the froms and store them in global storage
- Driver Register
  -  redirects to /driver/register since user is not driver yent and requires to be registered as driver
- ReserverTrip:
  - adjust top posttion to fix overflow issues
- registerDriver.js
  - fix wrong endpont
  - creates and extra reducer to handle fullfilled responses in userSlice
