### PR TITLE
fix/front/PassenderDriverBtn.jsx (switch)

### DIFF
--- a/frontend/src/components/PassengerDriverBtn.jsx
+++ b/frontend/src/components/PassengerDriverBtn.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { PropTypes } from 'prop-types';
 
 const PassengerDriverBtn = ({ setDriverIsActive }) => {
-  const [active, setActive] = useState('Driver');
+  const [active, setActive] = useState('Passenger');
 
   const handlePassengerClick = () => {
     setActive('Passenger');


### PR DESCRIPTION
# Implemented Changes:
Update the initial `active` state in PassengerDriverBtn.jsx to show as selected the passenger at first render to correctly match the body(which at the beginning renders data for a passenger and not a driver.

## Original:
![image](https://github.com/Diegogagan2587/A-Dedo/assets/61764778/f9e56358-6a2f-4683-887e-734b7c7f6d13)
## Corrected:
![image](https://github.com/Diegogagan2587/A-Dedo/assets/61764778/669dafb3-f130-4bbc-a74c-6ffe97ad2273)
![image](https://github.com/Diegogagan2587/A-Dedo/assets/61764778/0fa8938a-d6dc-4901-b4ad-e9392e11350f)
